### PR TITLE
added step in pushing repository from command line

### DIFF
--- a/contribute.py
+++ b/contribute.py
@@ -40,6 +40,7 @@ def main():
 
     if repository is not None:
         run(['git', 'remote', 'add', 'origin', repository])
+        run(['git', 'branch', '-M', 'main'])
         run(['git', 'push', '-u', 'origin', 'main'])
 
     print('\nRepository generation ' +


### PR DESCRIPTION
I was getting an error and it failed to push to Github. I added this line with an extra git command, which is given by Github in their instructions for pushing an existing repository from the command line, which made it work for me.