### PR TITLE
Minimum Commits Daily.

### DIFF
--- a/contribute.py
+++ b/contribute.py
@@ -73,11 +73,16 @@ def message(date):
 
 def contributions_per_day(args):
     max_c = args.max_commits
+    min_c = args.min_commits
     if max_c > 20:
         max_c = 20
     if max_c < 1:
         max_c = 1
-    return randint(1, max_c)
+    if min_c < 1:
+        min_c = 1
+    if min_c > max_c:
+        min_c, max_c = max_c, min_c
+    return randint(min_c, max_c)
 
 
 def arguments(argsval):
@@ -92,6 +97,13 @@ def arguments(argsval):
                         from 1 to N times a day. The exact number of commits
                         is defined randomly for each day. The default value
                         is 10.""")
+    parser.add_argument('-mic', '--min_commits', type=int, default=1,
+                    required=False, help="""Defines the minimum amount of
+                    commits a day the script can make. Accepts a number
+                    from 1 to 20. If N is specified the script commits
+                    from N to max_commits times a day. The exact number of commits
+                    is defined randomly for each day. The default value
+                    is 1.""")
     parser.add_argument('-fr', '--frequency', type=int, default=80,
                         required=False, help="""Percentage of days when the
                         script performs commits. If N is specified, the script


### PR DESCRIPTION
New Command Line Argument --min_commits:
Added a new optional argument that allows users to specify the minimum number of commits they want the script to make each day. The argument ranges from 1 to 20, with a default value of 1. This additional feature gives users more control over the number of commits made daily.

Update to contributions_per_day function:
The function has been revised to incorporate the new min_commits argument. Now, the number of daily contributions is a random value between min_commits and max_commits (both inclusive). This change enhances the variability and customization of the script's operations.

Edge case handling for min_commits and max_commits:
Added checks to handle scenarios where min_commits may be greater than max_commits. In such cases, the values are swapped to maintain a valid commit range for the script. This is crucial to ensuring the robustness of the script when faced with unusual user inputs.