### PR TITLE
Support Negative Values for days_after Parameter in Contribution Script

### DIFF
--- a/contribute.py
+++ b/contribute.py
@@ -25,8 +25,8 @@ def main(def_args=sys.argv[1:]):
     if days_before < 0:
         sys.exit('days_before must not be negative')
     days_after = args.days_after
-    if days_after < 0:
-        sys.exit('days_after must not be negative')
+    if days_after + days_before < 0:
+        sys.exit('The absolute value of days_after cannot exceed the value of days_before')
     os.mkdir(directory)
     os.chdir(directory)
     run(['git', 'init', '-b', 'main'])
@@ -38,12 +38,10 @@ def main(def_args=sys.argv[1:]):
         run(['git', 'config', 'user.email', user_email])
 
     start_date = curr_date.replace(hour=20, minute=0) - timedelta(days_before)
-    for day in (start_date + timedelta(n) for n
-                in range(days_before + days_after)):
-        if (not no_weekends or day.weekday() < 5) \
-                and randint(0, 100) < frequency:
-            for commit_time in (day + timedelta(minutes=m)
-                                for m in range(contributions_per_day(args))):
+    end_date = curr_date + timedelta(days_after)
+    for day in (start_date + timedelta(n) for n in range((end_date - start_date).days)):
+        if (not no_weekends or day.weekday() < 5) and randint(0, 100) < frequency:
+            for commit_time in (day + timedelta(minutes=m) for m in range(contributions_per_day(args))):
                 contribute(commit_time)
 
     if repository is not None:
@@ -118,9 +116,8 @@ def arguments(argsval):
     parser.add_argument('-da', '--days_after', type=int, default=0,
                         required=False, help="""Specifies the number of days
                         after the current date until which the script will be
-                        adding commits. For example: if it is set to 30 the
-                        last commit will be on a future date which is the
-                        current date plus 30 days.""")
+                        adding commits. Negative values are allowed and indicate
+                        the script should stop committing before the current date.""")
     return parser.parse_args(argsval)
 
 


### PR DESCRIPTION
## Overview
This introduces the ability to use negative values for the `days_after` parameter in the GitHub contribution generation script. This enhancement increases the flexibility of the script, allowing users to specify a commit history that ends before the current date.

## Changes
- Modified the error check for `days_after` to ensure the sum of `days_before` and `days_after` is non-negative.
- Adjusted the commit generation loop to correctly handle negative values for `days_after`, enabling the script to create a commit history that can end before the current date.

## Impact
This change allows users to have more control over the date range for commit generation. It is particularly useful for scenarios where the user wants to backdate contributions but stop at a certain point before the current date.

## Examples
### Example 1: Standard Usage
- `days_before = 30`
- `days_after = 10`
This would generate commits from 30 days before the current date to 10 days after the current date.

### Example 2: Using Negative `days_after`
- `days_before = 30`
- `days_after = -5`
This would generate commits from 30 days before the current date and stop 5 days before the current date. It's particularly useful for creating a commit history that doesn't include the most recent days.

Credit to @jeremiah-shore who gave me this idea from a [suggestion](https://github.com/Shpota/github-activity-generator/issues/32#issue-1862153147)