### PR TITLE
Clarify command to avoid confusion

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -31,7 +31,7 @@ tools** which I encourage you to check:
 2. Download [the contribute.py script](https://github.com/Shpota/github-activity-generator/archive/master.zip) 
 and execute it passing the link on the created repository
 ```sh
-python contribute.py --repository=git@github.com:user/repo.git
+python contribute.py --repository=git@github.com:<user-name>/<repo-name.git>
 ```
 Now you have a repository with lots of changes in your GitHub account.
 Note: it takes several minutes for GitHub to reindex your activity.

--- a/.github/README.md
+++ b/.github/README.md
@@ -33,6 +33,8 @@ and execute it passing the link on the created repository
 ```sh
 python contribute.py --repository=git@github.com:<user-name>/<repo-name.git>
 ```
+Make sure you enter your user-name and repo-name in command.
+
 Now you have a repository with lots of changes in your GitHub account.
 Note: it takes several minutes for GitHub to reindex your activity.
 


### PR DESCRIPTION
I’ve gone through the Issues section of your repository, and I noticed that many people are facing the following issue:

```
fatal: Could not read from remote repository.
Please make sure you have the correct access rights
and the repository exists.
Repository generation completed successfully!
```

I also encountered this issue myself, and after some investigation, I found that the root cause was related to how the repository URL was being specified in the command.

To resolve this issue, I updated the README to clarify the correct usage. The command was not clear enough in its previous form, and many people were simply copy-pasting it without realizing the need to replace <user-name> and <repo-name>.

The new, clarified command is:
```
python contribute.py --repository=git@github.com:<user-name>/<repo-name>.git
```
This updated command should work without errors, as it explicitly shows where to replace the placeholders with the actual username and repository name.

I hope this change resolves the confusion for others as well.

Fixes issue #60 , #59, #37

 @Shpota 