### PR TITLE
Handle existing directory gracefully

### DIFF
--- a/contribute.py
+++ b/contribute.py
@@ -28,9 +28,7 @@ def main(def_args=sys.argv[1:]):
     if days_after < 0:
         sys.exit('days_after must not be negative')
     if os.path.exists(directory):
-    	print(f"Directory '{directory}' already exists.")
-    	print("Please remove it or choose a different repository.")
-    	sys.exit(1)
+    	sys.exit(f"Error: Directory '{directory}' already exists. Please remove it or choose a different repository.")
     os.mkdir(directory)
     os.chdir(directory)
     run(['git', 'init', '-b', 'main'])

--- a/contribute.py
+++ b/contribute.py
@@ -28,10 +28,9 @@ def main(def_args=sys.argv[1:]):
     if days_after < 0:
         sys.exit('days_after must not be negative')
     if os.path.exists(directory):
-    print(f"Directory '{directory}' already exists.")
-    print("Please remove it or choose a different repository.")
-    sys.exit(1)
-
+    	print(f"Directory '{directory}' already exists.")
+    	print("Please remove it or choose a different repository.")
+    	sys.exit(1)
     os.mkdir(directory)
     os.chdir(directory)
     run(['git', 'init', '-b', 'main'])

--- a/contribute.py
+++ b/contribute.py
@@ -27,6 +27,11 @@ def main(def_args=sys.argv[1:]):
     days_after = args.days_after
     if days_after < 0:
         sys.exit('days_after must not be negative')
+    if os.path.exists(directory):
+    print(f"Directory '{directory}' already exists.")
+    print("Please remove it or choose a different repository.")
+    sys.exit(1)
+
     os.mkdir(directory)
     os.chdir(directory)
     run(['git', 'init', '-b', 'main'])


### PR DESCRIPTION
## Summary

This change improves error handling when the target repository directory already exists.

## Previous behavior

Running contribute.py multiple times against the same repository caused:

FileExistsError: [WinError 183]

## New behavior

The script checks whether the directory already exists and exits gracefully with a helpful message instead of crashing.

## Tested

- Windows 11
- Python 3.14.5